### PR TITLE
DB 및 스키마 관련 제안

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,7 +9,7 @@ datasource db {
 
 model bug_reports {
   id            Int       @id @default(autoincrement())
-  user_id       String    @db.VarChar(50)
+  user_id       Int
   bug_image_url String?   @db.VarChar(255)
   bug_type      String?   @db.VarChar(255)
   bug_size      String?   @db.VarChar(255)
@@ -39,8 +39,8 @@ model chats {
 model matches {
   id                             Int          @id @default(autoincrement())
   bug_report_id                  Int?
-  hunter_id                      String       @db.VarChar(50)
-  helper_id                      String       @db.VarChar(50)
+  helper_id                      Int
+  hunter_id                      Int
   status                         String?      @db.VarChar(50)
   created_at                     DateTime?    @default(now()) @db.Timestamp(0)
   accepted_at                    DateTime?    @db.Timestamp(0)
@@ -57,7 +57,7 @@ model matches {
 
 model user_reviews {
   id          Int       @id @default(autoincrement())
-  user_id     String    @db.VarChar(50)
+  user_id     Int
   role        String?   @db.VarChar(50)
   score       Int?
   time_taken  Int?
@@ -70,7 +70,8 @@ model user_reviews {
 }
 
 model users {
-  id                               String         @id @db.VarChar(50)
+  id                               Int            @id @default(autoincrement())
+  kakao_id                         String         @db.VarChar(50)
   name                             String?        @db.VarChar(255)
   phone_number                     String?        @db.VarChar(20)
   location                         String?        @db.VarChar(255)

--- a/src/controllers/kakaoLoginController.ts
+++ b/src/controllers/kakaoLoginController.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import { getKakaoToken, getKakaoUserInfo } from '../services/kakaoLoginService';
-import { handleUserLogin, generateJwtToken } from '../services/userAuthService';
+import { handleUserLogin, generateJwtToken, handlUserInfoLogic } from '../services/userAuthService';
 
 // Kakao 로그인 URL 생성 - 사용자가 로그인 버튼을 눌렀을 때 이 URL로 이동시킵니다.
 export const kakaoLogin = (req: Request, res: Response): void => {
@@ -31,13 +31,13 @@ export const kakaoCallback = async (req: Request, res: Response) => {
   }
 };
 
-// //회원가입 ,회원 정보 입력
-// export const userInfo = async (req: Request, res: Response): Promise<void> => {
-//   try {
-//     //await handlUserInfoLogic(req);
-//    //res.status(result.status).json(result.data);
-//   } catch (error) {
-//     console.error('Error during registration:', error);
-//     res.status(500).send('Registration failed');
-//   }
-// };
+//회원가입 ,회원 정보 입력
+export const userInfo = async (req: Request, res: Response): Promise<void> => {
+  try {
+    // handlUserInfoLogic이 직접 응답(res)을 처리함
+    await handlUserInfoLogic(req, res);
+  } catch (error) {
+    console.error('Error during user information update:', error);
+    res.status(500).json({ message: 'Registration failed due to an internal error' });
+  }
+};

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -1,19 +1,46 @@
 import { Request, Response, NextFunction } from 'express';
-import jwt from 'jsonwebtoken';
+import jwt, { JwtPayload } from 'jsonwebtoken';
 
-// 인증 미들웨어
-export const authenticateToken = (req: Request, res: Response, next: NextFunction) => {
+interface AuthenticatedRequest extends Request {
+  userId?: string;
+}
+
+export const authenticateToken = (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+): void => {
   const authHeader = req.headers.authorization;
+
   if (!authHeader) {
-    return res.status(401).json({ message: 'Authorization header missing' });
+    res.status(401).json({ message: 'Authorization header missing' });
+    return;
   }
 
   const token = authHeader.split(' ')[1];
+  if (!token) {
+    res.status(401).json({ message: 'Token is missing in authorization header' });
+    return;
+  }
+
+  const JWT_SECRET = process.env.JWT_SECRET;
+  if (!JWT_SECRET) {
+    throw new Error('JWT_SECRET must be defined in environment variables');
+  }
+
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET as string);
-    (req as any).userId = (decoded as any).userId; // req에 userId를 추가
+    const decoded = jwt.verify(token, JWT_SECRET) as JwtPayload | string;
+
+    if (typeof decoded !== 'object' || !decoded.userId) {
+      res.status(401).json({ message: 'Invalid token payload' });
+      return;
+    }
+
+    req.userId = decoded.userId as string;
     next();
   } catch (error) {
-    return res.status(401).json({ message: 'Invalid or expired token' });
+    console.error('Token verification failed:', error);
+    res.status(401).json({ message: 'Invalid or expired token' });
+    return;
   }
 };

--- a/src/routes/kakaoLoginRoute.ts
+++ b/src/routes/kakaoLoginRoute.ts
@@ -1,11 +1,11 @@
 import express from 'express';
-import { kakaoLogin, kakaoCallback } from '../controllers/kakaoLoginController';
+import { kakaoLogin, kakaoCallback, userInfo } from '../controllers/kakaoLoginController';
 import { authenticateToken } from '../middlewares/authMiddleware';
 
 const router = express.Router();
 
 router.get('/user/login/kakao', kakaoLogin);
 router.get('/login/kakao/callback', kakaoCallback);
-//router.post('/user/info', authenticateToken, userInfo);
+router.post('/user/info', authenticateToken, userInfo);
 
 export const kakaoLoginRoute = router;

--- a/src/services/userAuthService.ts
+++ b/src/services/userAuthService.ts
@@ -16,20 +16,22 @@ export const generateJwtToken = (userId: string): string => {
 export const handleUserLogin = async (user: KaKaoUserDTO) => {
   try {
     // 데이터베이스에 사용자 존재 여부 확인
-    let existingUser = await prisma.users.findUnique({
-      where: { id: user.id.toString() },
+    let existingUser = await prisma.users.findFirst({
+      where: {
+        kakao_id: user.id.toString(),
+      }
     });
 
     // 사용자가 없으면 새로 추가 필요
     if (!existingUser) {
       existingUser = await prisma.users.create({
         data: {
-          id: user.id.toString(),
+          kakao_id: user.id.toString(),
           name: user.nickname,
         },
       });
     }
-    
+
     return existingUser;
   } catch (error) {
     console.error('Failed to handle user login:', error);
@@ -39,7 +41,7 @@ export const handleUserLogin = async (user: KaKaoUserDTO) => {
 
 // 확장된 Request 타입 정의
 interface AuthenticatedRequest extends Request {
-  userId?: string;
+  userId: string;
 }
 
 //회원 가입 -> 사용자 정보 추가 로직
@@ -48,7 +50,7 @@ export const handlUserInfoLogic =  async (
   res: Response
 ) => {
     const {  gender, ageRange, phoneNumber, location, termsAccepted } = req.body;
-  
+
     // //약관 동의 필드 필수 true
     // if (!termsAccepted) {
     //   return {
@@ -56,11 +58,11 @@ export const handlUserInfoLogic =  async (
     //     data: { message: 'Terms must be accepted to register' },
     //   };
     // }
-   
+
     //userId를 조회해서 db에 접근한 후 req.body에 있는 정보 db에 추가 저장하는 코드
     try {
       await prisma.users.update({
-        where: { id: req.userId?.toString() as string},
+        where: { id: parseInt(req.userId) },
         data: {
           gender,
           age_group: ageRange,
@@ -70,7 +72,7 @@ export const handlUserInfoLogic =  async (
           updated_at: new Date(),
         },
       });
-      
+
       res.status(200).json({ message: 'User registration details updated successfully' });
     } catch (error) {
       console.error('Failed to update user registration details:', error);
@@ -78,6 +80,5 @@ export const handlUserInfoLogic =  async (
     }
 
 };
-  
 
-  
+

--- a/src/services/userAuthService.ts
+++ b/src/services/userAuthService.ts
@@ -16,20 +16,22 @@ export const generateJwtToken = (userId: string): string => {
 export const handleUserLogin = async (user: KaKaoUserDTO) => {
   try {
     // 데이터베이스에 사용자 존재 여부 확인
-    let existingUser = await prisma.users.findUnique({
-      where: { id: user.id.toString() },
+    let existingUser = await prisma.users.findFirst({
+      where: {
+        kakao_id: user.id.toString(),
+      }
     });
 
     // 사용자가 없으면 새로 추가 필요
     if (!existingUser) {
       existingUser = await prisma.users.create({
         data: {
-          id: user.id.toString(),
+          kakao_id: user.id.toString(),
           name: user.nickname,
         },
       });
     }
-    
+
     return existingUser;
   } catch (error) {
     console.error('Failed to handle user login:', error);
@@ -42,7 +44,7 @@ export const handleUserLogin = async (user: KaKaoUserDTO) => {
 //   req: Request<{}, {}, RegistrationRequestBody>, res: Response
 // ) => {
 //     const {  gender, ageRange, phoneNumber, location, termsAccepted } = req.body;
-  
+
 //     // //약관 동의 필드 필수 true
 //     // if (!termsAccepted) {
 //     //   return {
@@ -64,7 +66,7 @@ export const handleUserLogin = async (user: KaKaoUserDTO) => {
 //           updated_at: new Date(),
 //         },
 //       });
-      
+
 //       res.status(200).json({ message: 'User registration details updated successfully' });
 //     } catch (error) {
 //       console.error('Failed to update user registration details:', error);
@@ -72,6 +74,5 @@ export const handleUserLogin = async (user: KaKaoUserDTO) => {
 //     }
 
 // };
-  
 
-  
+

--- a/src/services/userAuthService.ts
+++ b/src/services/userAuthService.ts
@@ -37,41 +37,47 @@ export const handleUserLogin = async (user: KaKaoUserDTO) => {
   }
 };
 
+// 확장된 Request 타입 정의
+interface AuthenticatedRequest extends Request {
+  userId?: string;
+}
+
 //회원 가입 -> 사용자 정보 추가 로직
-// export const handlUserInfoLogic = async (
-//   req: Request<{}, {}, RegistrationRequestBody>, res: Response
-// ) => {
-//     const {  gender, ageRange, phoneNumber, location, termsAccepted } = req.body;
+export const handlUserInfoLogic =  async (
+  req: AuthenticatedRequest,
+  res: Response
+) => {
+    const {  gender, ageRange, phoneNumber, location, termsAccepted } = req.body;
   
-//     // //약관 동의 필드 필수 true
-//     // if (!termsAccepted) {
-//     //   return {
-//     //     status: 400,
-//     //     data: { message: 'Terms must be accepted to register' },
-//     //   };
-//     // }
-
-//     //userId를 조회해서 db에 접근한 후 req.body에 있는 정보 db에 추가 저장하는 코드
-//     try {
-//       await prisma.users.update({
-//         where: { id: req.userId as string },
-//         data: {
-//           gender,
-//           age_group: ageRange,
-//           phone_number: phoneNumber,
-//           location,
-//           terms_accepted: termsAccepted ? 1 : 0,
-//           updated_at: new Date(),
-//         },
-//       });
+    // //약관 동의 필드 필수 true
+    // if (!termsAccepted) {
+    //   return {
+    //     status: 400,
+    //     data: { message: 'Terms must be accepted to register' },
+    //   };
+    // }
+   
+    //userId를 조회해서 db에 접근한 후 req.body에 있는 정보 db에 추가 저장하는 코드
+    try {
+      await prisma.users.update({
+        where: { id: req.userId?.toString() as string},
+        data: {
+          gender,
+          age_group: ageRange,
+          phone_number: phoneNumber,
+          location,
+          terms_accepted: termsAccepted ? 1 : 0,
+          updated_at: new Date(),
+        },
+      });
       
-//       res.status(200).json({ message: 'User registration details updated successfully' });
-//     } catch (error) {
-//       console.error('Failed to update user registration details:', error);
-//       res.status(500).json({ message: 'Failed to update user registration details' });
-//     }
+      res.status(200).json({ message: 'User registration details updated successfully' });
+    } catch (error) {
+      console.error('Failed to update user registration details:', error);
+      res.status(500).json({ message: 'Failed to update user registration details' });
+    }
 
-// };
+};
   
 
   


### PR DESCRIPTION
# 몇가지 리뷰드릴 내용이 있어 PR 드립니다!

여태까지의 작업물은 브랜치를 합친 후 monorepo로 관리될 예정이기 때문에, 본 PR을 반드시 머지할 필요는 없습니다.

## Primary key 관련

현재 prisma 스키마 파일을 보니, users 스키마의 id값이 Varchar(50)으로 설정되어 있습니다. 카카오에서 반환한 id값을 사용자 id로 사용하시려는 영서님 의도는 알았으나, 다음과 같은 문제점이 발생할 수 있어요.

- String으로 키값을 지정하는 경우 검색 성능이 매우 떨어질 가능성이 있습니다. [이 링크](https://leo-bb.tistory.com/83)를 참조해보시면 좋을 것 같아요
- 카카오에서 사용하는 사용자 id가 그대로 노출될 가능성이 있어, 보안상 권장되지 않습니다.

따라서 제가 수정한 스키마의 내용을 반영하면 좋을 것 같네요.

다만, kakao_id의 경우 현재 PR에는 string으로 올려놨는데, [본 문서](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info-sample)의 내용에 따라 number로 바꿔야 할 필요가 있겠네요. 시간상 제가 바꾸지 못한 점 양해 부탁드립니다.

## 프로젝트 구조 관련

현재 routes/ 에서 라우팅을 관리하고, controller/의 모듈에서 라우트된 요청을 처리하도록 구현되어 있습니다.

명확한 책임 분리를 위해 이런 구조를 그대로 가져가도 좋지만, controller 모듈 내부에서 컨트롤러가 핸들링하는 요청이 어디서 온건지 바로 볼 수 없다는 단점이 있습니다.

controller 모듈 내부에 routes에서 처리하는 내용을 같이 담는 것은 어떨까요?

예시
```typescript
// import ~ from ...

const kakaoAuthController = express.Router();

const getKakaoToken = async (code: string): Promise<string> => {
  // ...
}

const getKakaoUserInfo = async (accessToken: string): Promise<any> => {
 // ...
};

kakaoAuthController.get('/user/login/kakao', kakaoLogin);
kakaoAuthController.get('/login/kakao/callback', kakaoCallback);
export default kakaoAuthController;
```

## DB 스키마 관련

![image](https://github.com/user-attachments/assets/83e72c82-2a4d-43bb-9963-de96c7972349)


Prisma를 쓰는 가장 큰 장점 중 하나가, prisma generate를 통해 db 스키마에 맞는 타입을 생성한 후 `그대로 사용할 수 있다`는 점입니다.

따라서 스키마와 다른 타입이 필요한 몇몇 경우를 제외하고는 prisma에서 생성된 타입을 사용하는 것이 좋을 것 같습니다!


다만 현재의 모델명 (users, reports)등은 `모델 타입`처럼 사용하기에 네이밍이 적절하지 않기에, 모델명을 User, Report 등으로 변경한 후 `@@map`을 통해 기존의 컬럼과 연결하면 더 좋겠네요. [이 페이지](https://www.prisma.io/docs/orm/prisma-schema/data-model/models)를 참조해보시면 좋을 것 같습니다.


예시
```typescript
import { User } from '@prisma/client';

const user: User = {
  // ...
}
```

한 번 생각해보시고 반영해주시면 더 좋을 것 같습니다.

고생하셨습니다!!!!