### PR TITLE
BugReport의 status 적용하기(SCRUM-119)

### DIFF
--- a/src/domains/alarm/controller.ts
+++ b/src/domains/alarm/controller.ts
@@ -60,7 +60,7 @@ export const hunterInfoController = async(
     return sendError(res, '유효한 hunter ID가 필요합니다.');
   }
 
-  const hunterInfo = await hunterInfoService(Number(hunterId));
+  const hunterInfo = await hunterInfoService(Number(hunterId),req.user);
   if (!hunterInfo) {
     return sendError(res, '해당 ID의 헌터 정보를 찾을 수 없습니다.');
   }

--- a/src/domains/alarm/service.ts
+++ b/src/domains/alarm/service.ts
@@ -55,7 +55,7 @@ export const sendAlarmService = async (reportId: number, user: User) => {
 };
 
 //헌터 정보 보내기
-export const hunterInfoService =  async (hunterId: number): Promise<HunterInfoResponse | null> => {
+export const hunterInfoService =  async (hunterId: number,  user: User): Promise<HunterInfoResponse | null> => {
 
   //ID로 헌터 찾기기
   const hunter = await prisma.user.findUnique({
@@ -85,6 +85,20 @@ export const hunterInfoService =  async (hunterId: number): Promise<HunterInfoRe
     created_at: review.created_at || new Date(),
   }));
 
+  // Match 테이블에서 헌터와 연결된 PENDING 상태의 Match ID 찾기
+  const match = await prisma.match.findFirst({
+    where: {
+      helper_id: user.id,
+      hunter_id: hunterId,
+      status: 'PENDING',
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  const matchId = match ? match.id : 0;
+
 
   //응답
   return {
@@ -96,6 +110,7 @@ export const hunterInfoService =  async (hunterId: number): Promise<HunterInfoRe
     avg_score: avgScore,
     trade_count: userReviews.length,
     user_reviews: userReviewsResponse,
-    pr_memo: hunter.pr_memo || ''
+    pr_memo: hunter.pr_memo || '',
+    match_id : matchId
   };
 }

--- a/src/domains/bugReport/service.ts
+++ b/src/domains/bugReport/service.ts
@@ -31,6 +31,7 @@ export const getAllBugReports = async (
         POINT(${currentLongitude},${currentLatitude})
       ) AS distance
     FROM BugReport
+    WHERE status = 'WAITING_MATCH'
     HAVING distance <= 5000
     ORDER BY distance ASC;
   `;

--- a/src/domains/match/controller.ts
+++ b/src/domains/match/controller.ts
@@ -12,10 +12,14 @@ export const modifyMatch = async(req: AuthenticatedRequest<MatchAcceptParams, Ma
   if(typeof req.body.accept == 'undefined' || !req.params.matchId) {
     return sendError(res, '잘못된 요청입니다.');
   }
+  const {matchId} = req.params;
+  if (isNaN(Number(matchId))){
+    return sendError(res, '유효한 matchId가 필요합니다.');
+  }
   const accept = req.body.accept;
   try {
-    await setMatchStatus(req.params.matchId, accept);
-    res.status(StatusCodes.ACCEPTED);
+    await setMatchStatus(Number(matchId), accept);
+    res.status(StatusCodes.ACCEPTED).json({ message: '매치 상태가 변경되었습니다.' });
   } catch(e) {
     console.error(e);
     sendError(res, '매치 상태 변경에 실패했습니다.', StatusCodes.INTERNAL_SERVER_ERROR);

--- a/src/domains/match/service.ts
+++ b/src/domains/match/service.ts
@@ -76,4 +76,12 @@ export const createMatch = async (user: User, reportID: number): Promise<void> =
       hunter: true, 
     },
   });  
+
+  // BugReport의 status를 PENDING으로 업데이트
+  await prisma.bugReport.update({
+    where: { id: reportID },
+    data: {
+      status: 'PENDING',
+    },
+  });
 };

--- a/src/domains/match/service.ts
+++ b/src/domains/match/service.ts
@@ -13,7 +13,33 @@ export const getMatchByUser = (user: User) => {
   });
 }
 
-export const setMatchStatus = (matchId: number, accept: boolean) => {
+export const setMatchStatus = async (matchId: number, accept: boolean) => {
+  // accept가 false일 때 bugReport status를 WAITING_MATCH로 바꾸기
+  const match = await prisma.match.findUnique({
+    where: {
+      id: matchId,
+    },
+    include: {
+      bug_report: true,
+    },
+  });
+
+  if (!match) {
+    throw new Error("해당 Match를 찾을 수 없습니다.");
+  }
+
+  if (!accept && match.bug_report) {
+    await prisma.bugReport.update({
+      data: {
+        status: 'WAITING_MATCH',
+      },
+      where: {
+        id: match.bug_report.id,
+      },
+    });
+  }
+
+  //accept에 따라 Match status를 바꾸기
   return prisma.match.update({
     data: {
       status: accept ? 'MATCH_ACCEPTED' : 'MATCH_REJECTED',

--- a/src/domains/user/types.d.ts
+++ b/src/domains/user/types.d.ts
@@ -21,4 +21,5 @@ export interface HunterInfoResponse {
   trade_count: number;
   user_reviews: UserReviewResponse[];
   pr_memo: string;
+  match_id:number;
 }


### PR DESCRIPTION
## 1. BugReport 리스트 조회할 때 status 적용하기
리스트 조회 시 bugReport의 status가 PENDING 이나 COMPLETED이면 조회되지 않게 수정하였습니다
![image](https://github.com/user-attachments/assets/ffac05a0-bef4-4a9a-802f-f9a866d269b3)
이전 버전에서 리스트를 조회했을 때 제일 먼저 조회되었던 2번을 PENDING으로 바꾸고 테스트하였습니다
![image](https://github.com/user-attachments/assets/61e30457-0183-4029-bf71-7f64db68d3e5)

## 2. 핼피가 지원한 헌터의 정보를 조회할 때 해당 Match 레코드의 matchId도 함께 반환하기
핼피가 헌터의 정보를 조회하고 난 뒤 헌터의 지원을 수락하거나 거절을 합니다. 이 때 matchId를 이용하여 수락,거절을 하기 때문에 이 단계에서 matchId를 함께 반환하도록 하였습니다.
![image](https://github.com/user-attachments/assets/29e21a69-db61-4827-9a8f-9f1f00b2082f)

## 3. 핼피가 헌터의 지원을 거절했을 때 BugReport의 status를 다시 WAITING_MATCH로 바꾸기
핼피가 헌터의 지원을 거절하면 다른 헌터의 지원을 다시 기다려야 합니다. 그래서 bugReport 리스트를 조회할 때 다시 나타나게 하기 위해서 status를 변경하는 것이 필요할 것 같아 코드를 추가하고 DB에서 status가 정상적으로 바뀌는지 테스트해 보았습니다.
이렇게 수정하던 중 MatchAcceptParams 이 type을 사용하고 싶었는데 req.params.matchId를 했더니 number로 받지 않고 string으로 받아져서 controller 코드에서 강제로 타입 변환을 시켰습니다...

## 4. 헌터가 핼피한테 지원할 때 bugReport의 status를 PENDING으로 바꾸기
 헌터가 핼피에게 지원하기 전 정보를 수정하거나 pr_memo와 함께 정보를 추가하여 전송할 때 bugReport의 status를 PENDING으로 바꾸어 다른 사람들이 BugReport를 조회할 때 나타나지 않도록 합니다.
![image](https://github.com/user-attachments/assets/2f4a68f6-6d69-42b9-bb64-952fa0c2ed6f)
![image](https://github.com/user-attachments/assets/4558b7fa-5a32-4942-8f91-58dfd0278e94)
