### PR TITLE
헌팅 과정에서 일어나는 로직 (SCRUM-120)

### DIFF
--- a/src/domains/hunting/controller.ts
+++ b/src/domains/hunting/controller.ts
@@ -1,0 +1,65 @@
+import { Request, Response } from 'express';
+import { sendError } from '@/utils/response';
+import { AuthenticatedRequest } from '@/types/express';
+import { StatusCodes } from 'http-status-codes';
+import {
+    GetBugReportPriceResponse, 
+    TradeAcceptParams, 
+    TradeAcceptBody
+} from '@/domains/hunting/types';
+import {
+    BugReportPrice,
+    setBugReportStatus
+} from '@/domains/hunting/service';
+
+//거래 취소, 거래 마치기 -> bugReport 상태 변경
+export const modifyBugReportStatus = async(req: AuthenticatedRequest<TradeAcceptParams,TradeAcceptBody >, res: Response) => {
+  if(! req.user) {
+    return sendError(res, '로그인된 사용자가 아닙니다.', StatusCodes.UNAUTHORIZED);
+  }
+  if(typeof req.body.trade == 'undefined' || !req.params.matchId) {
+    return sendError(res, '잘못된 요청입니다.');
+  }
+
+  const {matchId} = req.params;
+  if (isNaN(Number(matchId))){
+    return sendError(res, '유효한 matchId가 필요합니다.');
+  }
+  const trade = req.body.trade;
+
+  try {
+    await setBugReportStatus(Number(matchId), trade);
+    res.status(StatusCodes.ACCEPTED).json({ message: 'bugReport 상태가 변경되었습니다.' });
+  } catch(e) {
+    console.error(e);
+    sendError(res, 'bugReport 상태 변경에 실패했습니다.', StatusCodes.INTERNAL_SERVER_ERROR);
+  }
+}
+
+// 사냥 가격 조회
+export const getBugReportPrice = async (
+  req: AuthenticatedRequest<{matchId: string},{}>,
+  res: Response<GetBugReportPriceResponse>
+) => {
+  if(! req.user) {
+    return sendError(res, '로그인된 사용자가 아닙니다.', StatusCodes.UNAUTHORIZED);
+  }
+
+  try {
+    const { matchId }  = req.params;
+    console.log(Number(matchId))
+    if (!matchId || isNaN(Number(matchId))) {
+      return sendError(res, '유효한 match ID를 제공해야 합니다.');
+    }
+
+    const BugReportPriceRes = await BugReportPrice(Number(matchId));
+    if (!BugReportPriceRes) {
+      return sendError(res, '해당 ID의 버그 리포트 가격을 찾을 수 없습니다.');
+    }
+
+    res.status(StatusCodes.OK).json(BugReportPriceRes);
+  } catch (error) {
+    console.error('Error fetching bug report details:', error);
+    return sendError(res, '버그 리포트 가격을 가져오는 중 오류가 발생했습니다.',500);
+  }
+};

--- a/src/domains/hunting/route.ts
+++ b/src/domains/hunting/route.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+import { authenticateToken } from '@/middlewares/authMiddleware';
+import {
+    modifyBugReportStatus,
+    getBugReportPrice
+} from '@/domains/hunting/controller';
+
+const router = express.Router();
+
+router.put('/hunting/:matchId', authenticateToken, modifyBugReportStatus);
+router.get('/hunting/:matchId/price', authenticateToken, getBugReportPrice);
+
+export const huntingRoute = router;

--- a/src/domains/hunting/service.ts
+++ b/src/domains/hunting/service.ts
@@ -1,0 +1,73 @@
+import {GetBugReportPriceResponse} from '@/domains/hunting/types';
+import prisma from '@/utils/database';
+
+// 공통 로직: matchId로 BugReport 조회
+const getMatchAndBugReport = async (matchId: number) => {
+    // Match 테이블에서 matchId로 해당 Match와 BugReport 조회
+    const match = await prisma.match.findUnique({
+      where: { id: matchId },
+      include: { bug_report: true },
+    });
+  
+    if (!match || !match.bug_report) {
+      throw new Error('해당 matchId에 대한 Match 또는 BugReport를 찾을 수 없습니다.');
+    }
+  
+    return { bugReport: match.bug_report };
+}
+  
+//거래 종료, 거래 취소
+export const setBugReportStatus = async (matchId: number, trade: boolean) => {
+    try {
+        const { bugReport } = await getMatchAndBugReport(matchId);
+  
+      // trade에 따라 BugReport와 Match 상태 업데이트
+      if (trade) {
+        // trade가 true (거래 종료)
+        await prisma.bugReport.update({
+          where: { id: bugReport.id },
+          data: { status: 'COMPLETED' }, 
+        });
+  
+        await prisma.match.update({
+          where: { id: matchId },
+          data: { status: 'MATCH_CLOSED', resolved_at: new Date() }, 
+        });
+
+        //채팅 강제 종료?
+
+      } else {
+        // trade가 false(거래 취소)
+        await prisma.bugReport.update({
+          where: { id: bugReport.id },
+          data: { status: 'WAITING_MATCH' }, 
+        });
+  
+        await prisma.match.update({
+          where: { id: matchId },
+          data: { status: 'MATCH_REJECTED', resolved_at: new Date() },
+        });
+      }
+  
+      console.log(`BugReport와 Match의 status가 성공적으로 업데이트 : ${matchId}`);
+    } catch (error) {
+      console.error("Error in setBugReportStatus:", error);
+      throw new Error("BugReport 및 Match 상태 업데이트 중 오류가 발생했습니다.");
+    }
+  };
+  
+  
+// 게시물 가격 조회 로직
+export const BugReportPrice = async (matchId: number): Promise<GetBugReportPriceResponse | null> => {
+    try {
+        const { bugReport } = await getMatchAndBugReport(matchId);
+    
+        // 반환할 객체
+        return {
+          price: bugReport.price
+        };
+      } catch (error) {
+        console.error("Error in BugReportPrice:", error);
+        throw new Error("BugReport 가격 조회 중 오류가 발생했습니다.");
+      }
+};

--- a/src/domains/hunting/service.ts
+++ b/src/domains/hunting/service.ts
@@ -3,23 +3,27 @@ import prisma from '@/utils/database';
 
 // 공통 로직: matchId로 BugReport 조회
 const getMatchAndBugReport = async (matchId: number) => {
-    // Match 테이블에서 matchId로 해당 Match와 BugReport 조회
-    const match = await prisma.match.findUnique({
-      where: { id: matchId },
-      include: { bug_report: true },
-    });
-  
-    if (!match || !match.bug_report) {
-      throw new Error('해당 matchId에 대한 Match 또는 BugReport를 찾을 수 없습니다.');
+  // matchId로 연결된 BugReport 조회
+  const bugReport_matchId = await prisma.bugReport.findFirst({
+    where: {
+      matches: {
+        some: { id: matchId }
+      }
     }
-  
-    return { bugReport: match.bug_report };
+  });
+
+  if (!bugReport_matchId) {
+    throw new Error('해당 matchId에 대한 Match 또는 BugReport를 찾을 수 없습니다.');
+  }
+  return bugReport_matchId;
 }
+
+
   
 //거래 종료, 거래 취소
 export const setBugReportStatus = async (matchId: number, trade: boolean) => {
     try {
-        const { bugReport } = await getMatchAndBugReport(matchId);
+      const bugReport  = await getMatchAndBugReport(matchId);
   
       // trade에 따라 BugReport 상태 업데이트
       if (trade) {
@@ -56,9 +60,7 @@ export const setBugReportStatus = async (matchId: number, trade: boolean) => {
 // 게시물 가격 조회 로직
 export const BugReportPrice = async (matchId: number): Promise<GetBugReportPriceResponse | null> => {
     try {
-        const { bugReport } = await getMatchAndBugReport(matchId);
-    
-        // 반환할 객체
+        const bugReport = await getMatchAndBugReport(matchId);
         return {
           price: bugReport.price
         };

--- a/src/domains/hunting/service.ts
+++ b/src/domains/hunting/service.ts
@@ -21,20 +21,13 @@ export const setBugReportStatus = async (matchId: number, trade: boolean) => {
     try {
         const { bugReport } = await getMatchAndBugReport(matchId);
   
-      // trade에 따라 BugReport와 Match 상태 업데이트
+      // trade에 따라 BugReport 상태 업데이트
       if (trade) {
         // trade가 true (거래 종료)
         await prisma.bugReport.update({
           where: { id: bugReport.id },
           data: { status: 'COMPLETED' }, 
         });
-  
-        await prisma.match.update({
-          where: { id: matchId },
-          data: { status: 'MATCH_CLOSED', resolved_at: new Date() }, 
-        });
-
-        //채팅 강제 종료?
 
       } else {
         // trade가 false(거래 취소)
@@ -42,12 +35,15 @@ export const setBugReportStatus = async (matchId: number, trade: boolean) => {
           where: { id: bugReport.id },
           data: { status: 'WAITING_MATCH' }, 
         });
-  
-        await prisma.match.update({
-          where: { id: matchId },
-          data: { status: 'MATCH_REJECTED', resolved_at: new Date() },
-        });
       }
+
+      //Match 상태 업데이트
+      await prisma.match.update({
+        where: { id: matchId },
+        data: { status: 'MATCH_CLOSED', resolved_at: new Date() }, 
+      });
+
+      //채팅 강제 종료?
   
       console.log(`BugReport와 Match의 status가 성공적으로 업데이트 : ${matchId}`);
     } catch (error) {

--- a/src/domains/hunting/types.d.ts
+++ b/src/domains/hunting/types.d.ts
@@ -1,0 +1,9 @@
+export type TradeAcceptParams = {
+    matchId: number;
+}
+
+export type TradeAcceptBody = {
+    trade: boolean;
+}
+  
+export type GetBugReportPriceResponse = Pick<BugReport, 'price'>

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { WebSocketServer } from 'ws';
 import * as http from 'node:http';
 import { route } from '@/domains/review/route';
 import { handleSocketConnection } from '@/domains/chat/socket';
+import { huntingRoute } from './domains/hunting/route';
 
 const app = express();
 const DEV_PORT = 3000;
@@ -40,6 +41,7 @@ app.use(API_PREFIX, bugReportRoute);
 app.use(API_PREFIX, userRoute);
 app.use(API_PREFIX, matchRoute);
 app.use(API_PREFIX, alarmRoute);
+app.use(API_PREFIX, huntingRoute);
 app.use(API_PREFIX, route);
 
 app.get('*', (req: Request, res: Response) => {


### PR DESCRIPTION
## 1. 헌팅 과정 중 거래를 취소하는 상황
Match 테이블에서 BugReportId를 찾아서 조회하지 않고 BugReport에서 matchId를 이용해 바로 조회하도록 구현했습니다. 
BugReport status를 WAITING_MATCH로 바꾸고, Match status를 MATCH_CLOSED로 변경했습니다
BugReport를 조회할 때 다시 해당 리포트가 조회 돼야 하기 때문에 WAITIN_MATCH로 상태를 업데이트 했습니다
또, Match는 수락 되었지만 이후 거래가 취소되었으므로 MATCH_CLOSED로 상태를 업데이트 했습니다
![image](https://github.com/user-attachments/assets/93183d4e-d0a0-4d6a-b022-2cf632ac5df2)

## 2. 채팅이 끝나고 거래를 시작할 때 가격 반환
matchId를 이용해서 위와 같이 BugReport를 조회하여 price를 반환합니다
![image](https://github.com/user-attachments/assets/c1853d4a-785c-4bf4-a914-b77e5ff94de4)

## 3. 거래가 모두 끝나고 거래를 성공적으로 종료하는 상황
matchId를 이용해서 위와 같이 BugReport를 조회합니다
BugReport status를 COMPLETED로 바꾸고 Match status를 MATCH_CLOSED로 변경했습니다
![image](https://github.com/user-attachments/assets/4e2e8f8b-7724-4af1-99af-5ddc6cbaed39)

p.s. Match의 status가 MATCH_CLOSED로 변경된 뒤 채팅이 강제로 종료되는 기능이 필요할 것 같습니다!