### PR TITLE
Socket close api 작성 (SCRUM-121)

### DIFF
--- a/src/domains/chat/socket/session/Session.ts
+++ b/src/domains/chat/socket/session/Session.ts
@@ -13,6 +13,14 @@ export default class Session {
   private readonly _ws: WebSocket;
   private readonly _user: User;
   public static userSessions: { [key: number]: Session } = {};
+  public static closeSession(userId: number) {
+    const session = Session.userSessions[userId];
+    if(session) {
+      session.close();
+      return true;
+    }
+    return false;
+  }
   private async createMessage(message: string) {
     const match = await this.getMatch() as Match;
     if(!this.isMatchOpen(match)) {
@@ -55,9 +63,14 @@ export default class Session {
       this.handleClose();
     }
   }
-  public handleClose() {
+  public close() {
     this.websocket.close();
-    delete Session.userSessions[this.user.id]; // destruction
+    if(Session.userSessions[this.user.id]) {
+      delete Session.userSessions[this.user.id];
+    }
+  }
+  public handleClose() {
+    this.close();
   }
   public readAllChats() {
     return prisma.chat.updateMany({


### PR DESCRIPTION
## 작업한 내용

퀵챗을 닫아야 할 때 (ex. 헬피나 헌터가 매칭을 그만뒀을 경우, 매칭이 정상적으로 끝난 경우) Websocket 연결을 클라이언트에서 끊을 수 있게끔 했으나, 서버단에서 소켓을 닫는 로직이 필요하다고 생각돼서 본 pr을 올리게 되었습니다.

## 소켓을 닫는 방법

![Frame 1 (5)](https://github.com/user-attachments/assets/a7af6986-c18d-4168-bf96-fa92361b5d61)


사용자가 `wss://buln.ing?token=access_token`으로 연결을 요청하면 현재 퀵챗을 사용할 수 있는 상태인지 확인한 후 Session 클래스의 static 인스턴스에 `사용자 id => 사용자와 통신하는 세션` 형식으로 저장합니다. 아래 함수를 이용하면 형성된 소켓을 닫을 수 있어요.

```typescript
import Session from '@/domains/chat/socket/session/Session;
Socket.closeSession(userId); // 해당 사용자 id로 만들어진 소켓을 close. 정상적으로 close된 경우 true, 아닌 경우 false를 반환.
```

매치를 닫는 엔드포인트를 구현하시면서 위의 로직을 사용하시면 좋을 것 같습니다!!