### PR TITLE
리프레쉬 토큰 및 액세스 토큰 재발급 기능 구현 (SCRUM-122)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@aws-sdk/credential-providers": "^3.716.0",
         "@prisma/client": "^5.21.1",
         "axios": "^1.7.7",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "cross-env": "^7.0.3",
         "date-fns": "^4.1.0",
@@ -30,6 +31,7 @@
       },
       "devDependencies": {
         "@swc/core": "^1.9.3",
+        "@types/cookie-parser": "^1.4.8",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
         "@types/jsonwebtoken": "^9.0.7",
@@ -2545,6 +2547,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.8.tgz",
+      "integrity": "sha512-l37JqFrOJ9yQfRQkljb41l0xVphc7kg5JTjjr+pLRZ0IyZ49V4BQ8vbF4Ut2C2e+WH4al3xD3ZwYwIUfnbT4NQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cors": {
       "version": "2.8.17",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
@@ -3180,6 +3191,26 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "engines": {
         "node": ">= 0.6"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3494,10 +3494,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
-      "license": "MIT",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -3518,7 +3517,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -3533,6 +3532,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -4784,10 +4787,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
-      "license": "MIT"
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "description": "",
   "devDependencies": {
     "@swc/core": "^1.9.3",
+    "@types/cookie-parser": "^1.4.8",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/jsonwebtoken": "^9.0.7",
@@ -33,6 +34,7 @@
     "@aws-sdk/credential-providers": "^3.716.0",
     "@prisma/client": "^5.21.1",
     "axios": "^1.7.7",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "cross-env": "^7.0.3",
     "date-fns": "^4.1.0",

--- a/src/domains/auth/controller.ts
+++ b/src/domains/auth/controller.ts
@@ -1,13 +1,13 @@
 import { Request, Response } from 'express';
 import { AuthenticatedRequest } from '@/types/express';
-import {RegistrationRequestBody} from '@/domains/user/types';
+import { RegistrationRequestBody } from '@/domains/user/types';
 import { sendError } from '@/utils/response';
-import { StatusCodes } from 'http-status-codes';
+import { ReasonPhrases, StatusCodes } from 'http-status-codes';
 import {
-  generateJwtToken,
+  generateJWT,
   getKakaoToken,
   getKakaoUserInfo, handleUserInfoInput,
-  handleUserLogin,
+  handleUserLogin, reissueAccessToken,
 } from './service';
 
 // Kakao 로그인 URL 생성 - 사용자가 로그인 버튼을 눌렀을 때 이 URL로 이동시킵니다.
@@ -21,17 +21,26 @@ export const kakaoLogin = (req: Request, res: Response): void => {
 export const kakaoCallback = async (req: Request, res: Response) => {
   const { code } = req.query;
   try {
-    const accessToken = await getKakaoToken(code as string);
-    const userInfo = await getKakaoUserInfo(accessToken);
+    const kakaoAccessToken = await getKakaoToken(code as string);
+    const userInfo = await getKakaoUserInfo(kakaoAccessToken);
     const { id: kakaoId, properties: { nickname } } = userInfo;
 
     // id 조회 시 만약 db에서 새로운 사용자일 경우 새롭게 저장
     const user = await handleUserLogin({ id: kakaoId, nickname });
 
     // JWT 토큰 생성 후 응답
-    const jwtToken = generateJwtToken(user.id, kakaoId);
+    const accessToken = generateJWT(user.id, kakaoId);
+    const refreshToken = generateJWT(user.id, kakaoId, 'refresh');
     const baseRedirectionUrl = process.env.NODE_ENV === 'production' ? process.env.REDIRECT_URL : process.env.REDIRECT_URL_DEV;
-    const redirectUrl = `${baseRedirectionUrl}/auth/login?access_token=${jwtToken}`;
+    const redirectUrl = `${baseRedirectionUrl}/auth/login?access_token=${accessToken}`;
+
+    res.cookie('refreshToken', refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production', // HTTPS 환경에서만 전송
+      sameSite: 'strict',
+      path: '/api/refresh',
+    });
+
     res.redirect(redirectUrl as string);
 
   } catch (error) {
@@ -39,6 +48,29 @@ export const kakaoCallback = async (req: Request, res: Response) => {
     res.status(500).send('Kakao login failed');
   }
 };
+
+export const reissue = async(req: Request, res: Response) => {
+  const { refreshToken } = req.cookies;
+  const authHeader = req.headers.authorization;
+  if(! authHeader) {
+    sendError(res, ReasonPhrases.UNAUTHORIZED, StatusCodes.UNAUTHORIZED);
+    return;
+  }
+  const accessToken = authHeader.split(' ')[1];
+  if(! refreshToken || ! accessToken) {
+    sendError(res, ReasonPhrases.UNAUTHORIZED, StatusCodes.UNAUTHORIZED);
+    return;
+  }
+  try {
+    const reissuedAccessToken = reissueAccessToken(accessToken, refreshToken);
+    res.json({
+      access_token: reissuedAccessToken
+    });
+  } catch(error) {
+    console.error('Token verification faild: ', error);
+    sendError(res, '토큰 검증에 실패했습니다', StatusCodes.UNAUTHORIZED);
+  }
+}
 
 //회원가입 ,회원 정보 입력
 export const userInfo = async (

--- a/src/domains/auth/route.ts
+++ b/src/domains/auth/route.ts
@@ -1,5 +1,10 @@
 import express from 'express';
-import { kakaoLogin, kakaoCallback, userInfo } from '@/domains/auth/controller';
+import {
+  kakaoLogin,
+  kakaoCallback,
+  userInfo,
+  reissue,
+} from '@/domains/auth/controller';
 import { authenticateToken } from '@/middlewares/authMiddleware';
 
 const router = express.Router();
@@ -7,5 +12,6 @@ const router = express.Router();
 router.get('/user/login/kakao', kakaoLogin);
 router.get('/login/kakao/callback', kakaoCallback);
 router.post('/user/info', authenticateToken, userInfo);
+router.post('/reissue', reissue);
 
 export const kakaoLoginRoute = router;

--- a/src/domains/auth/service.ts
+++ b/src/domains/auth/service.ts
@@ -1,11 +1,12 @@
 import axios from 'axios';
 import { ExtendedJWTPayload } from '@/domains/auth/types';
 import jwt from 'jsonwebtoken';
-import { KaKaoUserDTO, RegistrationRequestBody } from '@/domains/user/types';
+import type { KaKaoUserDTO, RegistrationRequestBody } from '@/domains/user/types';
 import prisma from '@/utils/database';
 import type { User } from '@prisma/client';
 import { registrationSchema } from '@/domains/user/validator';
 import { z } from 'zod';
+import { getJWTSecret, verifyJWT } from '@/utils/auth';
 
 // 카카오 서버에 액세스 토큰 요청
 export const getKakaoToken = async (code: string): Promise<string> => {
@@ -32,6 +33,20 @@ export const getKakaoToken = async (code: string): Promise<string> => {
   }
 };
 
+export const reissueAccessToken = (accessToken: string, refreshToken: string): string => {
+  const decodedRefresh = verifyJWT(refreshToken, 'refresh');
+  const decodedAccess = verifyJWT(accessToken, 'access', true);
+  if(decodedRefresh.id !== decodedAccess.id || decodedRefresh.kakao_id !== decodedAccess.kakao_id) {
+    throw new Error('액세스 토큰과 리프레쉬 토큰의 정보가 일치하지 않습니다.');
+  }
+  const SECRET = getJWTSecret('access');
+  if(! SECRET) {
+    throw new Error('액세스 토큰 시크릿이 정의되지 않았습니다.');
+  }
+  // TODO: 액세스 토큰이 banned 테이블에 있는지 확인 (추후 구현)
+  return generateJWT(decodedAccess.id, decodedAccess.kakao_id);
+}
+
 // 액세스 토큰을 사용하여 사용자 정보 요청
 export const getKakaoUserInfo = async (accessToken: string): Promise<any> => {
     try {
@@ -46,12 +61,16 @@ export const getKakaoUserInfo = async (accessToken: string): Promise<any> => {
     }
 };
 
-export const generateJwtToken = (id: number, kakaoId: string): string => {
+export const generateJWT = (id: number, kakaoId: string, tokenType: 'refresh' | 'access' = 'access'): string => {
   const payload: ExtendedJWTPayload = {
     id, kakao_id: kakaoId
   };
-  return jwt.sign(payload, process.env.JWT_SECRET as string, {
-    expiresIn: '1h',
+  const secret = getJWTSecret(tokenType);
+  if(! secret) {
+    throw new Error('토큰 시크릿 값이 정의되지 않았습니다.');
+  }
+  return jwt.sign(payload, secret, {
+    expiresIn: tokenType === 'access' ? '1h' : '30d',
   });
 };
 

--- a/src/domains/chat/socket/index.ts
+++ b/src/domains/chat/socket/index.ts
@@ -16,12 +16,12 @@ export const handleSocketConnection = async(ws: WebSocket, req: http.IncomingMes
     }));
     return;
   }
-  const JWT_SECRET = process.env.JWT_SECRET;
-  if (!JWT_SECRET) {
-    throw new Error('JWT_SECRET must be defined in environment variables');
+  const ACCESS_SECRET = process.env.ACCESS_SECRET;
+  if (!ACCESS_SECRET) {
+    throw new Error('ACCESS_SECRET must be defined in environment variables');
   }
   try {
-    const decoded = jwt.verify(token, JWT_SECRET) as ExtendedJWTPayload | string;
+    const decoded = jwt.verify(token, ACCESS_SECRET) as ExtendedJWTPayload | string;
     if (typeof decoded !== 'object' || !decoded.id) {
       closeSocket(ws, '토큰이 올바르지 않습니다.');
       return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import * as http from 'node:http';
 import { route } from '@/domains/review/route';
 import { handleSocketConnection } from '@/domains/chat/socket';
 import { huntingRoute } from './domains/hunting/route';
+import cookieParser from 'cookie-parser';
 
 const app = express();
 const DEV_PORT = 3000;
@@ -28,6 +29,7 @@ app.use(express.json({ limit: '1mb' }));
 app.use(cors({
   origin: '*'
 }));
+app.use(cookieParser());
 
 app.use((req: Request, res: Response, next: NextFunction) => {
   if (req.path.startsWith('/api')) {

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -1,11 +1,10 @@
 import type { Response, NextFunction } from 'express';
-import jwt from 'jsonwebtoken';
 import type { AuthenticatedRequest } from '@/types/express';
 import prisma from '@/utils/database';
 import { User } from '@prisma/client';
 import { sendError } from '@/utils/response';
 import { ReasonPhrases, StatusCodes } from 'http-status-codes';
-import { ExtendedJWTPayload } from '@/domains/auth/types';
+import { verifyJWT } from '@/utils/auth';
 
 export const authenticateToken = async (
   req: AuthenticatedRequest,
@@ -25,18 +24,8 @@ export const authenticateToken = async (
     return;
   }
 
-  const JWT_SECRET = process.env.JWT_SECRET;
-  if (!JWT_SECRET) {
-    throw new Error('JWT_SECRET must be defined in environment variables');
-  }
-
   try {
-    const decoded = jwt.verify(token, JWT_SECRET) as ExtendedJWTPayload | string;
-
-    if (typeof decoded !== 'object' || !decoded.id) {
-      sendError(res, '토큰 구조가 올바르지 않습니다.', StatusCodes.UNAUTHORIZED);
-      return;
-    }
+    const decoded = verifyJWT(token);
 
     req.user = await prisma.user.findUnique({
       where: {
@@ -45,7 +34,7 @@ export const authenticateToken = async (
     }) as User;
     next();
   } catch (error) {
-    console.error('Token verification failed:', error);
+    console.error('Token verification failed: ', error);
     sendError(res, '토큰 검증에 실패했습니다.', StatusCodes.UNAUTHORIZED);
     return;
   }

--- a/src/types/auth.d.ts
+++ b/src/types/auth.d.ts
@@ -1,0 +1,1 @@
+export type TokenType = 'access' | 'refresh';

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,24 @@
+import jwt from 'jsonwebtoken';
+import { ExtendedJWTPayload } from '@/domains/auth/types';
+import type { TokenType } from '@/types/auth';
+
+export const verifyJWT = (
+  token: string, tokenType: TokenType = 'access', ignoreExpiration: boolean = false) => {
+  const SECRET = getJWTSecret(tokenType);
+  if (!SECRET) {
+    throw new Error('토큰 시크릿 값이 정의되지 않았습니다.');
+  }
+  const decoded = jwt.verify(token, SECRET, {
+    ignoreExpiration
+  }) as ExtendedJWTPayload;
+  if(typeof decoded !== 'object' || !decoded.id) {
+    throw new Error('토큰 구조가 올바르지 않습니다.');
+  }
+  return decoded;
+};
+
+export const getJWTSecret = (tokenType: TokenType = 'access') => {
+  return tokenType === 'access' ?
+    process.env.ACCESS_SECRET :
+    process.env.REFRESH_SECRET;
+}


### PR DESCRIPTION
## 작업한 내용

리프레쉬 토큰을 발급하고, 리프레쉬 토큰을 이용해서 액세스 토큰을 발급하는 기능을 구현했습니다.

## 리프레쉬 토큰 발급

리프레쉬의 경우 SameSite: Strict, httponly 옵션의 쿠키로 클라이언트단에 `refreshToken`이라는 이름으로 추가됩니다. 클라이언트에서 카카오 로그인을 완료한 후 액세스 토큰을 전달하는 시점에 발급되고, 클라이언트에서는 이 값에 액세스할 수 없습니다.

## 액세스 토큰 재발급

`/api/reissue` 엔드포인트로 POST 요청을 보내면 됩니다. 대신 만료된 액세스 토큰을 헤더에 포함해야 하고, 리프레쉬 토큰은 로그인 시 자동으로 쿠키에 저장되니 신경쓰지 마시고 그냥 POST 요청만 보내면 됩니다.

![image](https://github.com/user-attachments/assets/db1436b9-bd5e-42fe-89a1-82d17d36af09)

## 비고

액세스 토큰과 리프레쉬 토큰의 시크릿이 서로 다르고, 이 둘을 서로 구별하기 위해 환경변수 `JWT_SECRET`을 `ACCESS_SECRET`으로 변경했고, `REFRESH_SECRET`을 새로운 환경변수로 추가했습니다. 변수 내용은 디스코드에 업로드했으니 확인해주세요. 서버에는 이미 적용해뒀습니다.