### PR TITLE
헌터의 지원 수락/거절 알림(SCRUM-123)

### DIFF
--- a/src/domains/alarm/service.ts
+++ b/src/domains/alarm/service.ts
@@ -47,7 +47,10 @@ export const sendAlarmService = async (reportId: number, user: User) => {
         title: "벌레를 잡아줄 사람이 나타났어요!",
         body: `우리 동네 헌터의 정보를 빠르게 확인해 보세요`,
       },
-      data:{user: `${user.id}`},
+      data:{
+        type: "hunter_applied", 
+        user: `${user.id}`
+      },
     };
 
     // FCM을 통해 알림 전송

--- a/src/domains/match/service.ts
+++ b/src/domains/match/service.ts
@@ -1,5 +1,6 @@
 import { User } from '@prisma/client';
 import prisma from '@/utils/database';
+import { messaging } from '@/utils/firebase';
 
 export const getMatchByUser = (user: User) => {
   return prisma.match.findFirst({
@@ -21,6 +22,7 @@ export const setMatchStatus = async (matchId: number, accept: boolean) => {
     },
     include: {
       bug_report: true,
+      hunter: true,
     },
   });
 
@@ -37,6 +39,31 @@ export const setMatchStatus = async (matchId: number, accept: boolean) => {
         id: match.bug_report.id,
       },
     });
+  }
+
+  // FCM
+  const fcmToken = match?.hunter.fcm_token;
+
+  if (typeof fcmToken !== 'string' || fcmToken.trim() === '') {
+    throw new Error("유효하지 않은 FCM token입니다.");
+  }
+
+  // 알림 메시지 설정
+  const message = {
+    token: fcmToken,
+    data: {
+      type: accept ? 'hunter_accepted' : 'hunter_rejected',
+      hunter: `${match.hunter.id}`,
+      helpee: `${match.helper_id}`,
+    },
+  };
+
+  // 알림 전송
+  try {
+    const response = await messaging.send(message);
+    console.log('FCM 메시지가 성공적으로 전송되었습니다:', response);
+  } catch (error) {
+    console.error('FCM 메시지 전송 중 오류 발생:', error);
   }
 
   //accept에 따라 Match status를 바꾸기


### PR DESCRIPTION
## 작업 내용
핼피가 헌터의 지원을 수락하고 거절함에 따라 헌터의 화면이 변경 되어야 합니다. 헌터의 환경이 변경되는 진입점을 만들기 위해 firebase의 알림을 사용하였습니다. 이에 따라 알림이 여러 개가 되므로 메시지의 data에 type을 추가하여 알림을 구분하도록 하였습니다.

## 테스트
![image](https://github.com/user-attachments/assets/fe44ede7-a72b-4da6-a59d-c44d8fc69bbb)
![image](https://github.com/user-attachments/assets/f6429845-d341-4b7b-a85b-d85728cd8787)
local에서 콘솔로 알림이 잘 가는지 확인했어요!