### PR TITLE
매칭 종료 시 채팅 세션 종료(SCRUM-124)

### DIFF
--- a/src/domains/hunting/controller.ts
+++ b/src/domains/hunting/controller.ts
@@ -28,7 +28,7 @@ export const modifyBugReportStatus = async(req: AuthenticatedRequest<TradeAccept
   const trade = req.body.trade;
 
   try {
-    await setBugReportStatus(Number(matchId), trade);
+    await setBugReportStatus(Number(matchId), trade, req.user);
     res.status(StatusCodes.ACCEPTED).json({ message: 'bugReport 상태가 변경되었습니다.' });
   } catch(e) {
     console.error(e);

--- a/src/domains/hunting/controller.ts
+++ b/src/domains/hunting/controller.ts
@@ -12,29 +12,50 @@ import {
     setBugReportStatus
 } from '@/domains/hunting/service';
 
-//거래 취소, 거래 마치기 -> bugReport 상태 변경
-export const modifyBugReportStatus = async(req: AuthenticatedRequest<TradeAcceptParams,TradeAcceptBody >, res: Response) => {
-  if(! req.user) {
+//거래 취소, 거래 마치기 -> bugReport 상태 변경,채팅 종료
+export const modifyBugReportStatus = async(req: AuthenticatedRequest<TradeAcceptParams, TradeAcceptBody>, res: Response) => {
+  if (!req.user) {
     return sendError(res, '로그인된 사용자가 아닙니다.', StatusCodes.UNAUTHORIZED);
   }
-  if(typeof req.body.trade == 'undefined' || !req.params.matchId) {
+  
+  if (typeof req.body.trade === 'undefined' || !req.params.matchId) {
     return sendError(res, '잘못된 요청입니다.');
   }
 
-  const {matchId} = req.params;
-  if (isNaN(Number(matchId))){
+  const { matchId } = req.params;
+  if (isNaN(Number(matchId))) {
     return sendError(res, '유효한 matchId가 필요합니다.');
   }
+
   const trade = req.body.trade;
 
   try {
-    await setBugReportStatus(Number(matchId), trade, req.user);
-    res.status(StatusCodes.ACCEPTED).json({ message: 'bugReport 상태가 변경되었습니다.' });
-  } catch(e) {
+    const { bugReportUpdated, matchUpdated, chatClosed } = await setBugReportStatus(Number(matchId), trade, req.user);
+
+    // 모든 과정이 정상적으로 처리된 경우
+    if (bugReportUpdated && matchUpdated && chatClosed) {
+      return res.status(StatusCodes.ACCEPTED).json({
+        message: 'bugReport 상태가 변경되었고, 채팅 세션이 종료되었습니다.',
+        bugReportUpdated,
+        matchUpdated,
+        chatClosed
+      });
+    }
+
+    // 일부 과정이 실패한 경우
+    return res.status(StatusCodes.OK).json({
+      message: 'bugReport 상태 변경 시 일부 과정이 실패했습니다.',
+      bugReportUpdated,
+      matchUpdated,
+      chatClosed
+    });
+
+  } catch (e) {
     console.error(e);
-    sendError(res, 'bugReport 상태 변경에 실패했습니다.', StatusCodes.INTERNAL_SERVER_ERROR);
+    return sendError(res, 'bugReport 상태 변경에 실패했습니다.', StatusCodes.INTERNAL_SERVER_ERROR);
   }
-}
+};
+
 
 // 사냥 가격 조회
 export const getBugReportPrice = async (

--- a/src/domains/hunting/service.ts
+++ b/src/domains/hunting/service.ts
@@ -23,48 +23,44 @@ const getMatchAndBugReport = async (matchId: number) => {
 
   
 //거래 종료, 거래 취소
-export const setBugReportStatus = async (matchId: number, trade: boolean, user:User) => {
-    try {
-      const bugReport  = await getMatchAndBugReport(matchId);
-  
-      // trade에 따라 BugReport 상태 업데이트
-      if (trade) {
-        // trade가 true (거래 종료)
-        await prisma.bugReport.update({
-          where: { id: bugReport.id },
-          data: { status: 'COMPLETED' }, 
-        });
+export const setBugReportStatus = async (matchId: number, trade: boolean, user: User) => {
+  try {
+    const bugReport = await getMatchAndBugReport(matchId);
 
-      } else {
-        // trade가 false(거래 취소)
-        await prisma.bugReport.update({
-          where: { id: bugReport.id },
-          data: { status: 'WAITING_MATCH' }, 
-        });
-      }
+    let bugReportUpdated = false;
+    let matchUpdated = false;
+    let chatClosed = false;
 
-      //Match 상태 업데이트
-      await prisma.match.update({
-        where: { id: matchId },
-        data: { status: 'MATCH_CLOSED', resolved_at: new Date() }, 
-      });
+    // trade에 따라 BugReport 상태 업데이트
+    const updatedBugReport = await prisma.bugReport.update({
+      where: { id: bugReport.id },
+      data: { status: trade ? 'COMPLETED' : 'WAITING_MATCH' }, 
+    });
 
-      // 채팅 강제 종료
-      const isClosed = Socket.closeSession(user.id);
-
-      if (isClosed) {
-        console.log(`채팅 세션 종료 완료: 사용자 ${user.id}`);
-      } else {
-        console.log(`채팅 세션 종료 실패: 사용자 ${user.id}`);
-        throw new Error("채팅 세션 종료 중 오류가 발생했습니다.");
-      }
-  
-      console.log(`BugReport와 Match의 status가 성공적으로 업데이트 : ${matchId}`);
-    } catch (error) {
-      console.error("Error in setBugReportStatus:", error);
-      throw new Error("BugReport 및 Match 상태 업데이트 중 오류가 발생했습니다.");
+    if (updatedBugReport) {
+      bugReportUpdated = true;
     }
-  };
+
+    // Match 상태 업데이트
+    const updatedMatch = await prisma.match.update({
+      where: { id: matchId },
+      data: { status: 'MATCH_CLOSED', resolved_at: new Date() }, 
+    });
+
+    if (updatedMatch) {
+      matchUpdated = true;
+    }
+
+    // 채팅 강제 종료
+    chatClosed = Socket.closeSession(user.id);
+
+    return { bugReportUpdated, matchUpdated, chatClosed };
+  } catch (error) {
+    console.error("Error in setBugReportStatus:", error);
+    return { bugReportUpdated: false, matchUpdated: false, chatClosed: false };
+  }
+};
+
   
   
 // 게시물 가격 조회 로직

--- a/src/domains/hunting/service.ts
+++ b/src/domains/hunting/service.ts
@@ -49,13 +49,14 @@ export const setBugReportStatus = async (matchId: number, trade: boolean, user:U
         data: { status: 'MATCH_CLOSED', resolved_at: new Date() }, 
       });
 
-      //채팅 강제 종료
-      try {
-        Socket.closeSession(user.id);
-        console.log('채팅 세션이 성공적으로 종료되었습니다');
-      } catch (socketError) {
-        console.error(`채팅 세션 종료 중 오류 발생: ${socketError}`);
-        throw new Error("채팅 세션 종료 중 오류가 발생했습니다")
+      // 채팅 강제 종료
+      const isClosed = Socket.closeSession(user.id);
+
+      if (isClosed) {
+        console.log(`채팅 세션 종료 완료: 사용자 ${user.id}`);
+      } else {
+        console.log(`채팅 세션 종료 실패: 사용자 ${user.id}`);
+        throw new Error("채팅 세션 종료 중 오류가 발생했습니다.");
       }
   
       console.log(`BugReport와 Match의 status가 성공적으로 업데이트 : ${matchId}`);

--- a/src/domains/hunting/service.ts
+++ b/src/domains/hunting/service.ts
@@ -1,5 +1,7 @@
 import {GetBugReportPriceResponse} from '@/domains/hunting/types';
 import prisma from '@/utils/database';
+import Socket from '@/domains/chat/socket/session/Session';
+import { User } from '@prisma/client';
 
 // 공통 로직: matchId로 BugReport 조회
 const getMatchAndBugReport = async (matchId: number) => {
@@ -21,7 +23,7 @@ const getMatchAndBugReport = async (matchId: number) => {
 
   
 //거래 종료, 거래 취소
-export const setBugReportStatus = async (matchId: number, trade: boolean) => {
+export const setBugReportStatus = async (matchId: number, trade: boolean, user:User) => {
     try {
       const bugReport  = await getMatchAndBugReport(matchId);
   
@@ -47,7 +49,14 @@ export const setBugReportStatus = async (matchId: number, trade: boolean) => {
         data: { status: 'MATCH_CLOSED', resolved_at: new Date() }, 
       });
 
-      //채팅 강제 종료?
+      //채팅 강제 종료
+      try {
+        Socket.closeSession(user.id);
+        console.log('채팅 세션이 성공적으로 종료되었습니다');
+      } catch (socketError) {
+        console.error(`채팅 세션 종료 중 오류 발생: ${socketError}`);
+        throw new Error("채팅 세션 종료 중 오류가 발생했습니다")
+      }
   
       console.log(`BugReport와 Match의 status가 성공적으로 업데이트 : ${matchId}`);
     } catch (error) {


### PR DESCRIPTION
## 작업한 내용
헌팅을 진행하던 중 거래를 취소하거나 헌팅이 성공적으로 종료되어 거래가 종료되면 채팅 세션을 강제로 닫도록 추가했습니다!
API 하나로  3가지 작업을(BugReport의 status변경, Match의 status 변경, 채팅 세션 종료) 하기 때문에 어디서 오류가 났는지 알 수 있게 반환했습니다
소켓을 어떻게 여는지 몰라서 소켓이 실제로 잘 닫히는지는 테스트하지 못했어요.. develop 브랜치로 merge되고 나면 프론트분들과 함께 테스트해보겠습니다  
![image](https://github.com/user-attachments/assets/d9d75864-a057-4854-a29e-b74e66605ba5)
